### PR TITLE
ReportVersion::Tiny out Test::ReportPrereqs in

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -18,7 +18,7 @@ dir = script
 
 [AutoPrereqs]
 
-[ReportVersions::Tiny]
+[Test::ReportPrereqs]
 
 [MetaJSON]
 [MetaResources]


### PR DESCRIPTION
Hi! Thanks for maintaining Net-Proxy. This was my #cpan-prc assignment for June.

ReportVersion::Tiny seems to be deprecated, and outputs an error message that says Test::ReportPrereqs is recommended alternative.

~This was a low hanging fruit. I'm still looking into handshake issues, and will send another PR if I can figure out what's happening.~ Update: Sorry I couldn't get to the error messages.